### PR TITLE
Removed the yellow horizontal yellow line on "Explore Repositories" link and "home" link

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -15,9 +15,11 @@ a {
 a:hover {
   color:yellow;
   outline: none;
+  text-decoration: none;
 }
 a:active{
   outline: none;
+  text-decoration: none;
 }
 #wrapper {
   position: fixed;


### PR DESCRIPTION
Removed the yellow horizontal yellow line on "Explore Repositories" link and "home" link by setting text-decoration to none when Anchor tag is hovered or active, in the main.css file.